### PR TITLE
Fix nested anon type/union warning

### DIFF
--- a/R/s2-xptr.R
+++ b/R/s2-xptr.R
@@ -54,7 +54,11 @@ validate_s2_xptr <- function(x) {
 
 #' @export
 rep.s2_xptr <- function(x, ...) {
-  new_s2_xptr(NextMethod(), class(x))
+  if (length(x) == 0) {
+    new_s2_xptr(list(), class(x))
+  } else {
+    new_s2_xptr(NextMethod(), class(x))
+  }
 }
 
 #' @method rep_len s2_xptr

--- a/data-raw/update-s2.R
+++ b/data-raw/update-s2.R
@@ -102,6 +102,12 @@ print_next <- function() {
     "Replace calls to log(<int literal>), sqrt(<int literal>), and ldexp(<int literal>, ...) ",
     "with an explicit doouble (e.g., sqrt(3) -> sqrt(3.0) to fix build errors on CRAN Solaris"
   )
+  cli::cat_bullet(
+    "Ensure the code compiles on clang with -Wnested-anon-types. ",
+    "These errors can be fixed by declaring the anonymous types just above the union. ",
+    "(e.g., encoded_s2point_vector.h:91)"
+  )
+
   cli::cat_bullet("Replace `abort()` with `cpp_compat_abort()`")
   cli::cat_bullet("Replace `cerr`/`cout` with `cpp_compat_cerr`/`cpp_compat_cout`")
   cli::cat_bullet("Replace `srandom()` with `cpp_compat_srandom()`")

--- a/inst/include/s2/encoded_s2point_vector.h
+++ b/inst/include/s2/encoded_s2point_vector.h
@@ -49,22 +49,6 @@ void EncodeS2PointVector(absl::Span<const S2Point> points, CodingHint hint,
 // be initialized from an encoded format in constant time and then decoded on
 // demand.  This can be a big performance advantage when only a small part of
 // the data structure is actually used.
-
-struct CellIDStruct {
-  EncodedStringVector blocks;
-  uint64 base;
-  uint8 level;
-  bool have_exceptions;
-
-  // TODO(ericv): Use std::atomic_flag to cache the last point decoded in
-  // a thread-safe way.  This reduces benchmark times for actual polygon
-  // operations (e.g. S2ClosestEdgeQuery) by about 15%.
-};
-
-struct UncompressedStruct {
-  const S2Point* points;
-};
-
 class EncodedS2PointVector {
  public:
   // Constructs an uninitialized object; requires Init() to be called.
@@ -106,6 +90,26 @@ class EncodedS2PointVector {
   // TODO(ericv): Once additional formats have been implemented, consider
   // using std::variant<> instead.  It's unclear whether this would have
   // better or worse performance than the current approach.
+
+  // dd: These structs are anonymous in the upstream S2 code; however,
+  // this generates CMD-check failure due to the [-Wnested-anon-types]
+  // (anonymous types declared in an anonymous union are an extension)
+  // The approach here just names the types.
+  struct CellIDStruct {
+    EncodedStringVector blocks;
+    uint64 base;
+    uint8 level;
+    bool have_exceptions;
+
+    // TODO(ericv): Use std::atomic_flag to cache the last point decoded in
+    // a thread-safe way.  This reduces benchmark times for actual polygon
+    // operations (e.g. S2ClosestEdgeQuery) by about 15%.
+  };
+
+  struct UncompressedStruct {
+    const S2Point* points;
+  };
+
   enum Format : uint8 {
     UNCOMPRESSED = 0,
     CELL_IDS = 1,

--- a/tests/testthat/test-s2-xptr.R
+++ b/tests/testthat/test-s2-xptr.R
@@ -20,6 +20,8 @@ test_that("s2_xptr validation works", {
 })
 
 test_that("s2_xptr subsetting and concatenation work", {
+  expect_length(rep(new_s2_xptr(list()), 10), 0)
+
   xptr <- new_s2_xptr(list(NULL, NULL))
   expect_identical(xptr[1], new_s2_xptr(list(NULL)))
   expect_identical(xptr[[1]], xptr[1])


### PR DESCRIPTION
- Verified that the warnings were reproduced in the original code by adding `-Wnested-anon-types` to CPP_FLAGS in `Makevars.in`
- Named the structs to silence the warnings
- Documented the approach in data-raw/update-s2.R