### PR TITLE
Switch one PI to M_PI to support STRICT_R_HEADERS

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,4 +1,4 @@
-PKG_CPPFLAGS = -I../inst/include
+PKG_CPPFLAGS = -I../inst/include -DSTRICT_R_HEADERS
 PKG_LIBS = @libs@
 PKG_CXXFLAGS = @cflags@ -pthread
 CXX_STD = CXX11

--- a/src/s2-transformers.cpp
+++ b/src/s2-transformers.cpp
@@ -566,7 +566,7 @@ List cpp_s2_unary_union(List geog, List s2options) {
 
           // Check if the builder created a polygon whose boundary contained more than
           // half the earth (and invert it if so)
-          if (loop->GetArea() > (2 * PI)) {
+          if (loop->GetArea() > (2 * M_PI)) {
             loop->Invert();
           }
 


### PR DESCRIPTION
Dear s2 team,

The Rcpp team is trying to move towards defining `STRICT_R_HEADERS` by default.  Please the issue ticket at  https://github.com/RcppCore/Rcpp/issues/1158 for motivation and history.  In late April and early May, we identified around 51 packages needing changes (which we generally sent by PR or, in case of no known git repo, emailed patch).  We are thrilled to report that  38 have already made the changes, including some on CRAN.  We also accomodated one first fix in Rcpp itself -- the `cfloat` (or `float.h`) header is needed for the floating limits such as `DBL_MAX`.   A common remaining issue is use of `PI`.

And it appears that your most recent package change introduced a mild regression.  One line of code refers to `PI` where `M_PI` would make us whole.  This PR changes this.  It also adds a define for `STRICT_R_HEADERS` to test this, you are more than welcome to remove that define or place it elsewhere.  I can also remove it from the PR if you like.

As discussed in https://github.com/RcppCore/Rcpp/issues/1158, this is not urgent, but we of course welcome relatively prompt resolution at CRAN so when we continue to test for this (at a likely montly pace) so we do not get false positives as we will continue to use the CRAN set of packages (as opposed to hand-curated set of upstream dev versions).  

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.