### PR TITLE
Disable polyline validation on construction

### DIFF
--- a/src/s2geography/constructor.h
+++ b/src/s2geography/constructor.h
@@ -176,10 +176,13 @@ class PolylineConstructor : public Constructor {
       auto polyline = absl::make_unique<S2Polyline>();
       polyline->Init(std::move(points_));
 
-      if (options_.check() && !polyline->IsValid()) {
-        polyline->FindValidationError(&error_);
-        throw Exception(error_.text());
-      }
+      // Previous version of s2 didn't check for this, so in
+      // this check is temporarily disabled to avoid mayhem in
+      // reverse dependency checks.
+      // if (options_.check() && !polyline->IsValid()) {
+      //   polyline->FindValidationError(&error_);
+      //   throw Exception(error_.text());
+      // }
 
       polylines_.push_back(std::move(polyline));
     }


### PR DESCRIPTION
Fixes #190 to avoid reverse dependency mayhem (but in the future we should consider converting with `check = FALSE` which is a lot faster and a user can subsequently call `st_is_valid()` to check).