### PR TITLE
Fix more clang14 errors

### DIFF
--- a/src/s2/s2edge_distances.cc
+++ b/src/s2/s2edge_distances.cc
@@ -187,14 +187,16 @@ S1Angle GetDistance(const S2Point& x, const S2Point& a, const S2Point& b) {
 }
 
 // dd: changed return type to int because on new clang we get:
-// s2/s2edge_distances.cc:282:11: warning: use of bitwise '|' with boolean operands [-Wbitwise-instead-of-logical]
+// warning: use of bitwise '|' with boolean operands [-Wbitwise-instead-of-logical]
 int UpdateMinDistance(const S2Point& x, const S2Point& a, const S2Point& b,
                        S1ChordAngle* min_dist) {
   return AlwaysUpdateMinDistance<false>(x, a, b, min_dist);
 }
 
-bool UpdateMaxDistance(const S2Point& x, const S2Point& a, const S2Point& b,
-                       S1ChordAngle* max_dist) {
+// dd: changed return type to int because on new clang we get:
+// warning: use of bitwise '|' with boolean operands [-Wbitwise-instead-of-logical]
+int UpdateMaxDistance(const S2Point& x, const S2Point& a, const S2Point& b,
+                      S1ChordAngle* max_dist) {
   auto dist = max(S1ChordAngle(x, a), S1ChordAngle(x, b));
   if (dist > S1ChordAngle::Right()) {
     AlwaysUpdateMinDistance<true>(-x, a, b, &dist);
@@ -264,7 +266,9 @@ S2Point Project(const S2Point& x, const S2Point& a, const S2Point& b) {
   return Project(x, a, b, S2::RobustCrossProd(a, b));
 }
 
-bool UpdateEdgePairMinDistance(
+// dd: changed return type to int because on new clang we get:
+// warning: use of bitwise '|' with boolean operands [-Wbitwise-instead-of-logical]
+int UpdateEdgePairMinDistance(
     const S2Point& a0, const S2Point& a1,
     const S2Point& b0, const S2Point& b1,
     S1ChordAngle* min_dist) {
@@ -287,7 +291,9 @@ bool UpdateEdgePairMinDistance(
           UpdateMinDistance(b1, a0, a1, min_dist));
 }
 
-bool UpdateEdgePairMaxDistance(
+// dd: changed return type to int because on new clang we get:
+// warning: use of bitwise '|' with boolean operands [-Wbitwise-instead-of-logical]
+int UpdateEdgePairMaxDistance(
     const S2Point& a0, const S2Point& a1,
     const S2Point& b0, const S2Point& b1,
     S1ChordAngle* max_dist) {

--- a/src/s2/s2edge_distances.h
+++ b/src/s2/s2edge_distances.h
@@ -67,8 +67,8 @@ int UpdateMinDistance(const S2Point& x, const S2Point& a, const S2Point& b,
 // If the maximum distance from X to the edge AB is greater than "max_dist",
 // this method updates "max_dist" and returns true.  Otherwise it returns false.
 // The case A == B is handled correctly.
-bool UpdateMaxDistance(const S2Point& x, const S2Point& a, const S2Point& b,
-                       S1ChordAngle* max_dist);
+int UpdateMaxDistance(const S2Point& x, const S2Point& a, const S2Point& b,
+                      S1ChordAngle* max_dist);
 
 // Returns the maximum error in the result of UpdateMinDistance (and
 // associated functions such as UpdateMinInteriorDistance, IsDistanceLess,
@@ -147,15 +147,15 @@ S2Point InterpolateAtDistance(S1Angle ax, const S2Point& a, const S2Point& b);
 // Like UpdateMinDistance(), but computes the minimum distance between the
 // given pair of edges.  (If the two edges cross, the distance is zero.)
 // The cases a0 == a1 and b0 == b1 are handled correctly.
-bool UpdateEdgePairMinDistance(const S2Point& a0, const S2Point& a1,
-                               const S2Point& b0, const S2Point& b1,
-                               S1ChordAngle* min_dist);
+int UpdateEdgePairMinDistance(const S2Point& a0, const S2Point& a1,
+                              const S2Point& b0, const S2Point& b1,
+                              S1ChordAngle* min_dist);
 
 // As above, but for maximum distances.  If one edge crosses the antipodal
 // reflection of the other, the distance is Pi.
-bool UpdateEdgePairMaxDistance(const S2Point& a0, const S2Point& a1,
-                               const S2Point& b0, const S2Point& b1,
-                               S1ChordAngle* max_dist);
+int UpdateEdgePairMaxDistance(const S2Point& a0, const S2Point& a1,
+                              const S2Point& b0, const S2Point& b1,
+                              S1ChordAngle* max_dist);
 
 // Returns the pair of points (a, b) that achieves the minimum distance
 // between edges a0a1 and b0b1, where "a" is a point on a0a1 and "b" is a


### PR DESCRIPTION
This time verified via *fedora* + docker (original warnings do not reproduce using *ubuntu* Docker + clang-14).

```bash
# (Ubuntu + clang14 doesn't reproduce the warnings as far as I can tell)
# docker run --rm -it -v $(pwd):/pkg/s2 ubuntu:jammy
# apt-get update && apt-get install -y r-core clang-14 libssl-dev

# docker run --rm -it -v $(pwd):/pkg/s2 fedora:36
dnf install -y clang R openssl-devel

mkdir ~/.R && 
  echo "CC=clang-14" > ~/.R/Makevars &&
  echo "CXX=clang++-14" >> ~/.R/Makevars &&
  echo "CXX11=clang++-14" >> ~/.R/Makevars &&
  echo "CXX11STD=-std=c++11" >> ~/.R/Makevars &&
  echo "CFLAGS=-O2 -fexceptions -g -Wall" >> ~/.R/Makevars &&
  echo "CXXFLAGS=-O2 -fexceptions -g -Wall" >> ~/.R/Makevars &&
  echo "CXX11FLAGS=-O2 -fexceptions -g -Wall" >> ~/.R/Makevars &&
  echo "LDFLAGS=" >> ~/.R/Makevars 

# check clang version flags made it made it through
clang-14 --version
R CMD config CC
R CMD config CXX
R CMD config CXX11

R -e 'install.packages(c("wk", "Rcpp"), repos = "https://cloud.r-project.org")'
cd /pkg/s2
R CMD INSTALL . --preclean > install.out 2>&1
# (check for warnings in install.out)
```

