### PR TITLE
Fix data frame test

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # s2 (development version)
 
+- Fixed test for `as.data.frame()` for `s2_cell()` to comply with new wk
+  version and the latest release of R (#207).
+
 # s2 1.1.1
 
 - Fix new CRAN check warnings (#202, #203).  

--- a/tests/testthat/test-s2-cell.R
+++ b/tests/testthat/test-s2-cell.R
@@ -229,7 +229,7 @@ test_that("s2_cell can be put into a data.frame", {
     data.frame(geom = new_s2_cell(NA_real_)),
     new_data_frame(list(geom = new_s2_cell(NA_real_)))
   )
-  expect_error(as.data.frame(new_s2_cell(NA_real_)), "cannot coerce class")
+  expect_error(as.data.frame(new_s2_cell(NA_real_)), "cannot coerce")
 })
 
 test_that("s2_cell default format/print/str methods work", {


### PR DESCRIPTION
Fixes the data frame test after https://github.com/paleolimbot/wk/pull/166 (fixes #205). Previously this was only a problem on r-devel but it now looks like this has been in a released version.