### PR TITLE
Fix the unary union of the empty multipolygon

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 ^pkgdown$
 ^README\.Rmd$
 ^vignettes/articles$
+^\.clang-format$

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+---
+Language:        Cpp
+BasedOnStyle:  Google
+...

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -17,11 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: covr
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - Fixed test for `as.data.frame()` for `s2_cell()` to comply with new wk
   version and the latest release of R (#207).
+- Fix unary union of an empty multipolygon (#208).
 
 # s2 1.1.1
 

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -292,8 +292,12 @@ std::unique_ptr<PointGeography> s2_build_point(const Geography& geog) {
       GlobalOptions::OutputAction::OUTPUT_ACTION_ERROR,
       GlobalOptions::OutputAction::OUTPUT_ACTION_ERROR);
 
-  return std::unique_ptr<PointGeography>(
+  if (s2_is_empty(*geog_out)) {
+    return absl::make_unique<PointGeography>();
+  } else {
+    return std::unique_ptr<PointGeography>(
       dynamic_cast<PointGeography*>(geog_out.release()));
+  }
 }
 
 std::unique_ptr<PolylineGeography> s2_build_polyline(const Geography& geog) {
@@ -302,8 +306,12 @@ std::unique_ptr<PolylineGeography> s2_build_polyline(const Geography& geog) {
       GlobalOptions::OutputAction::OUTPUT_ACTION_INCLUDE,
       GlobalOptions::OutputAction::OUTPUT_ACTION_ERROR);
 
-  return std::unique_ptr<PolylineGeography>(
+  if (s2_is_empty(*geog_out)) {
+    return absl::make_unique<PolylineGeography>();
+  } else {
+    return std::unique_ptr<PolylineGeography>(
       dynamic_cast<PolylineGeography*>(geog_out.release()));
+  }
 }
 
 std::unique_ptr<PolygonGeography> s2_build_polygon(const Geography& geog) {
@@ -312,8 +320,12 @@ std::unique_ptr<PolygonGeography> s2_build_polygon(const Geography& geog) {
       GlobalOptions::OutputAction::OUTPUT_ACTION_ERROR,
       GlobalOptions::OutputAction::OUTPUT_ACTION_INCLUDE);
 
-  return std::unique_ptr<PolygonGeography>(
-      dynamic_cast<PolygonGeography*>(geog_out.release()));
+  if (s2_is_empty(*geog_out)) {
+    return absl::make_unique<PolygonGeography>();
+  } else {
+    return std::unique_ptr<PolygonGeography>(
+        dynamic_cast<PolygonGeography*>(geog_out.release()));
+  }
 }
 
 void RebuildAggregator::Add(const Geography& geog) { index_.Add(geog); }

--- a/src/s2geography/geography.h
+++ b/src/s2geography/geography.h
@@ -63,7 +63,7 @@ class Geography {
   // to be faster than using Region().GetCovering() directly and to
   // return a small number of cells that can be used to compute a possible
   // intersection quickly.
-  virtual void GetCellUnionBound(std::vector<S2CellId> *cell_ids) const;
+  virtual void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const;
 };
 
 // An Geography representing zero or more points using a std::vector<S2Point>
@@ -78,9 +78,9 @@ class PointGeography : public Geography {
   int num_shapes() const { return 1; }
   std::unique_ptr<S2Shape> Shape(int id) const;
   std::unique_ptr<S2Region> Region() const;
-  void GetCellUnionBound(std::vector<S2CellId> *cell_ids) const;
+  void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const;
 
-  const std::vector<S2Point> &Points() const { return points_; }
+  const std::vector<S2Point>& Points() const { return points_; }
 
  private:
   std::vector<S2Point> points_;
@@ -101,9 +101,9 @@ class PolylineGeography : public Geography {
   int num_shapes() const;
   std::unique_ptr<S2Shape> Shape(int id) const;
   std::unique_ptr<S2Region> Region() const;
-  void GetCellUnionBound(std::vector<S2CellId> *cell_ids) const;
+  void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const;
 
-  const std::vector<std::unique_ptr<S2Polyline>> &Polylines() const {
+  const std::vector<std::unique_ptr<S2Polyline>>& Polylines() const {
     return polylines_;
   }
 
@@ -117,7 +117,7 @@ class PolylineGeography : public Geography {
 // perspective).
 class PolygonGeography : public Geography {
  public:
-  PolygonGeography() : polygon_(new S2Polygon()) {}
+  PolygonGeography(): polygon_(new S2Polygon()) {}
   PolygonGeography(std::unique_ptr<S2Polygon> polygon)
       : polygon_(std::move(polygon)) {}
 
@@ -125,9 +125,9 @@ class PolygonGeography : public Geography {
   int num_shapes() const { return 1; }
   std::unique_ptr<S2Shape> Shape(int id) const;
   std::unique_ptr<S2Region> Region() const;
-  void GetCellUnionBound(std::vector<S2CellId> *cell_ids) const;
+  void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const;
 
-  const std::unique_ptr<S2Polygon> &Polygon() const { return polygon_; }
+  const std::unique_ptr<S2Polygon>& Polygon() const { return polygon_; }
 
  private:
   std::unique_ptr<S2Polygon> polygon_;
@@ -141,7 +141,7 @@ class GeographyCollection : public Geography {
 
   GeographyCollection(std::vector<std::unique_ptr<Geography>> features)
       : features_(std::move(features)), total_shapes_(0) {
-    for (const auto &feature : features_) {
+    for (const auto& feature : features_) {
       num_shapes_.push_back(feature->num_shapes());
       total_shapes_ += feature->num_shapes();
     }
@@ -151,7 +151,7 @@ class GeographyCollection : public Geography {
   std::unique_ptr<S2Shape> Shape(int id) const;
   std::unique_ptr<S2Region> Region() const;
 
-  const std::vector<std::unique_ptr<Geography>> &Features() const {
+  const std::vector<std::unique_ptr<Geography>>& Features() const {
     return features_;
   }
 
@@ -174,12 +174,12 @@ class ShapeIndexGeography : public Geography {
       MutableS2ShapeIndex::Options options = MutableS2ShapeIndex::Options())
       : shape_index_(options) {}
 
-  explicit ShapeIndexGeography(const Geography &geog) { Add(geog); }
+  explicit ShapeIndexGeography(const Geography& geog) { Add(geog); }
 
   // Add a Geography to the index, returning the last shape_id
   // that was added to the index or -1 if no shapes were added
   // to the index.
-  int Add(const Geography &geog) {
+  int Add(const Geography& geog) {
     int id = -1;
     for (int i = 0; i < geog.num_shapes(); i++) {
       id = shape_index_.Add(geog.Shape(i));
@@ -191,7 +191,7 @@ class ShapeIndexGeography : public Geography {
   std::unique_ptr<S2Shape> Shape(int id) const;
   std::unique_ptr<S2Region> Region() const;
 
-  const MutableS2ShapeIndex &ShapeIndex() const { return shape_index_; }
+  const MutableS2ShapeIndex& ShapeIndex() const { return shape_index_; }
 
  private:
   MutableS2ShapeIndex shape_index_;

--- a/src/s2geography/geography.h
+++ b/src/s2geography/geography.h
@@ -11,7 +11,7 @@
 namespace s2geography {
 
 class Exception : public std::runtime_error {
-public:
+ public:
   Exception(std::string what) : std::runtime_error(what.c_str()) {}
 };
 
@@ -23,7 +23,7 @@ public:
 // and underlying S2 objects), however, the interface is designed to allow
 // future abstractions where this is not the case.
 class Geography {
-public:
+ public:
   virtual ~Geography() {}
 
   // Returns 0, 1, or 2 if all Shape()s that are returned will have
@@ -69,7 +69,7 @@ public:
 // An Geography representing zero or more points using a std::vector<S2Point>
 // as the underlying representation.
 class PointGeography : public Geography {
-public:
+ public:
   PointGeography() {}
   PointGeography(S2Point point) { points_.push_back(point); }
   PointGeography(std::vector<S2Point> points) : points_(std::move(points)) {}
@@ -82,14 +82,14 @@ public:
 
   const std::vector<S2Point> &Points() const { return points_; }
 
-private:
+ private:
   std::vector<S2Point> points_;
 };
 
 // An Geography representing zero or more polylines using the S2Polyline class
 // as the underlying representation.
 class PolylineGeography : public Geography {
-public:
+ public:
   PolylineGeography() {}
   PolylineGeography(std::unique_ptr<S2Polyline> polyline) {
     polylines_.push_back(std::move(polyline));
@@ -107,7 +107,7 @@ public:
     return polylines_;
   }
 
-private:
+ private:
   std::vector<std::unique_ptr<S2Polyline>> polylines_;
 };
 
@@ -116,7 +116,7 @@ private:
 // perspective) can represent zero or more polygons (from the simple features
 // perspective).
 class PolygonGeography : public Geography {
-public:
+ public:
   PolygonGeography() : polygon_(new S2Polygon()) {}
   PolygonGeography(std::unique_ptr<S2Polygon> polygon)
       : polygon_(std::move(polygon)) {}
@@ -129,14 +129,14 @@ public:
 
   const std::unique_ptr<S2Polygon> &Polygon() const { return polygon_; }
 
-private:
+ private:
   std::unique_ptr<S2Polygon> polygon_;
 };
 
 // An Geography wrapping zero or more Geography objects. These objects
 // can be used to represent a simple features GEOMETRYCOLLECTION.
 class GeographyCollection : public Geography {
-public:
+ public:
   GeographyCollection() : total_shapes_(0) {}
 
   GeographyCollection(std::vector<std::unique_ptr<Geography>> features)
@@ -155,7 +155,7 @@ public:
     return features_;
   }
 
-private:
+ private:
   std::vector<std::unique_ptr<Geography>> features_;
   std::vector<int> num_shapes_;
   int total_shapes_;
@@ -169,7 +169,7 @@ private:
 // own any Geography objects that are added do it and thus is only
 // valid for the scope of those objects.
 class ShapeIndexGeography : public Geography {
-public:
+ public:
   ShapeIndexGeography(
       MutableS2ShapeIndex::Options options = MutableS2ShapeIndex::Options())
       : shape_index_(options) {}
@@ -193,8 +193,8 @@ public:
 
   const MutableS2ShapeIndex &ShapeIndex() const { return shape_index_; }
 
-private:
+ private:
   MutableS2ShapeIndex shape_index_;
 };
 
-} // namespace s2geography
+}  // namespace s2geography

--- a/src/s2geography/geography.h
+++ b/src/s2geography/geography.h
@@ -11,7 +11,7 @@
 namespace s2geography {
 
 class Exception : public std::runtime_error {
- public:
+public:
   Exception(std::string what) : std::runtime_error(what.c_str()) {}
 };
 
@@ -23,7 +23,7 @@ class Exception : public std::runtime_error {
 // and underlying S2 objects), however, the interface is designed to allow
 // future abstractions where this is not the case.
 class Geography {
- public:
+public:
   virtual ~Geography() {}
 
   // Returns 0, 1, or 2 if all Shape()s that are returned will have
@@ -63,13 +63,13 @@ class Geography {
   // to be faster than using Region().GetCovering() directly and to
   // return a small number of cells that can be used to compute a possible
   // intersection quickly.
-  virtual void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const;
+  virtual void GetCellUnionBound(std::vector<S2CellId> *cell_ids) const;
 };
 
 // An Geography representing zero or more points using a std::vector<S2Point>
 // as the underlying representation.
 class PointGeography : public Geography {
- public:
+public:
   PointGeography() {}
   PointGeography(S2Point point) { points_.push_back(point); }
   PointGeography(std::vector<S2Point> points) : points_(std::move(points)) {}
@@ -78,18 +78,18 @@ class PointGeography : public Geography {
   int num_shapes() const { return 1; }
   std::unique_ptr<S2Shape> Shape(int id) const;
   std::unique_ptr<S2Region> Region() const;
-  void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const;
+  void GetCellUnionBound(std::vector<S2CellId> *cell_ids) const;
 
-  const std::vector<S2Point>& Points() const { return points_; }
+  const std::vector<S2Point> &Points() const { return points_; }
 
- private:
+private:
   std::vector<S2Point> points_;
 };
 
 // An Geography representing zero or more polylines using the S2Polyline class
 // as the underlying representation.
 class PolylineGeography : public Geography {
- public:
+public:
   PolylineGeography() {}
   PolylineGeography(std::unique_ptr<S2Polyline> polyline) {
     polylines_.push_back(std::move(polyline));
@@ -101,13 +101,13 @@ class PolylineGeography : public Geography {
   int num_shapes() const;
   std::unique_ptr<S2Shape> Shape(int id) const;
   std::unique_ptr<S2Region> Region() const;
-  void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const;
+  void GetCellUnionBound(std::vector<S2CellId> *cell_ids) const;
 
-  const std::vector<std::unique_ptr<S2Polyline>>& Polylines() const {
+  const std::vector<std::unique_ptr<S2Polyline>> &Polylines() const {
     return polylines_;
   }
 
- private:
+private:
   std::vector<std::unique_ptr<S2Polyline>> polylines_;
 };
 
@@ -116,8 +116,8 @@ class PolylineGeography : public Geography {
 // perspective) can represent zero or more polygons (from the simple features
 // perspective).
 class PolygonGeography : public Geography {
- public:
-  PolygonGeography() {}
+public:
+  PolygonGeography() : polygon_(new S2Polygon()) {}
   PolygonGeography(std::unique_ptr<S2Polygon> polygon)
       : polygon_(std::move(polygon)) {}
 
@@ -125,23 +125,23 @@ class PolygonGeography : public Geography {
   int num_shapes() const { return 1; }
   std::unique_ptr<S2Shape> Shape(int id) const;
   std::unique_ptr<S2Region> Region() const;
-  void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const;
+  void GetCellUnionBound(std::vector<S2CellId> *cell_ids) const;
 
-  const std::unique_ptr<S2Polygon>& Polygon() const { return polygon_; }
+  const std::unique_ptr<S2Polygon> &Polygon() const { return polygon_; }
 
- private:
+private:
   std::unique_ptr<S2Polygon> polygon_;
 };
 
 // An Geography wrapping zero or more Geography objects. These objects
 // can be used to represent a simple features GEOMETRYCOLLECTION.
 class GeographyCollection : public Geography {
- public:
+public:
   GeographyCollection() : total_shapes_(0) {}
 
   GeographyCollection(std::vector<std::unique_ptr<Geography>> features)
       : features_(std::move(features)), total_shapes_(0) {
-    for (const auto& feature : features_) {
+    for (const auto &feature : features_) {
       num_shapes_.push_back(feature->num_shapes());
       total_shapes_ += feature->num_shapes();
     }
@@ -151,11 +151,11 @@ class GeographyCollection : public Geography {
   std::unique_ptr<S2Shape> Shape(int id) const;
   std::unique_ptr<S2Region> Region() const;
 
-  const std::vector<std::unique_ptr<Geography>>& Features() const {
+  const std::vector<std::unique_ptr<Geography>> &Features() const {
     return features_;
   }
 
- private:
+private:
   std::vector<std::unique_ptr<Geography>> features_;
   std::vector<int> num_shapes_;
   int total_shapes_;
@@ -169,17 +169,17 @@ class GeographyCollection : public Geography {
 // own any Geography objects that are added do it and thus is only
 // valid for the scope of those objects.
 class ShapeIndexGeography : public Geography {
- public:
+public:
   ShapeIndexGeography(
       MutableS2ShapeIndex::Options options = MutableS2ShapeIndex::Options())
       : shape_index_(options) {}
 
-  explicit ShapeIndexGeography(const Geography& geog) { Add(geog); }
+  explicit ShapeIndexGeography(const Geography &geog) { Add(geog); }
 
   // Add a Geography to the index, returning the last shape_id
   // that was added to the index or -1 if no shapes were added
   // to the index.
-  int Add(const Geography& geog) {
+  int Add(const Geography &geog) {
     int id = -1;
     for (int i = 0; i < geog.num_shapes(); i++) {
       id = shape_index_.Add(geog.Shape(i));
@@ -191,10 +191,10 @@ class ShapeIndexGeography : public Geography {
   std::unique_ptr<S2Shape> Shape(int id) const;
   std::unique_ptr<S2Region> Region() const;
 
-  const MutableS2ShapeIndex& ShapeIndex() const { return shape_index_; }
+  const MutableS2ShapeIndex &ShapeIndex() const { return shape_index_; }
 
- private:
+private:
   MutableS2ShapeIndex shape_index_;
 };
 
-}  // namespace s2geography
+} // namespace s2geography

--- a/tests/testthat/test-s2-transformers.R
+++ b/tests/testthat/test-s2-transformers.R
@@ -257,6 +257,13 @@ test_that("s2_union(x) works", {
   )
 })
 
+test_that("s2_union(x) works with empty input", {
+  expect_identical(
+    s2_as_text(s2_union("MULTIPOLYGON EMPTY")),
+    "GEOMETRYCOLLECTION EMPTY"
+  )
+})
+
 test_that("s2_union(x) works with polygons that have overlapping input regions", {
   # two outer loops
   txt <- "MULTIPOLYGON (((0 0, 0 1, 1 1, 1 0, 0 0)), ((0.1 0.9, 0.1 1.9, 1.1 1.9, 1.1 0.9, 0.1 0.9)))"


### PR DESCRIPTION
As identified in https://github.com/r-spatial/sf/issues/2053. A minimal reprex is `s2::s2_union("MULTIPOLYGON EMPTY")`.