### PR TITLE
Use .empty() over .size() comparisons to 0

### DIFF
--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -22,8 +22,8 @@ std::unique_ptr<Geography> s2_geography_from_layers(
     GlobalOptions::OutputAction polygon_layer_action) {
   // count non-empty dimensions
   bool has_polygon = !polygon->is_empty();
-  bool has_polylines = polylines.size() > 0;
-  bool has_points = points.size() > 0;
+  bool has_polylines = !polylines.empty();
+  bool has_points = !points.empty();
 
   // use the requstested dimensions to produce the right kind of EMTPY
   bool include_polygon =
@@ -350,7 +350,7 @@ void S2UnionAggregator::Add(const Geography& geog) {
     return;
   }
 
-  if (other_.size() == 0) {
+  if (other_.empty()) {
     other_.push_back(absl::make_unique<Node>());
     other_.back()->index1.Add(geog);
     return;
@@ -399,7 +399,7 @@ std::unique_ptr<Geography> S2UnionAggregator::Finalize() {
     }
   }
 
-  if (other_.size() == 0) {
+  if (other_.empty()) {
     return root_.Merge(options_);
   } else {
     std::unique_ptr<Geography> merged = other_[0]->Merge(options_);

--- a/src/s2geography/constructor.h
+++ b/src/s2geography/constructor.h
@@ -174,7 +174,7 @@ class PolylineConstructor : public Constructor {
   Result geom_end() {
     finish_points();
 
-    if (points_.size() > 0) {
+    if (!points_.empty()) {
       auto polyline = absl::make_unique<S2Polyline>();
       polyline->Init(std::move(points_));
 
@@ -195,11 +195,11 @@ class PolylineConstructor : public Constructor {
   std::unique_ptr<Geography> finish() {
     std::unique_ptr<PolylineGeography> result;
 
-    if (polylines_.size() > 0) {
+    if (polylines_.empty()) {
+      result = absl::make_unique<PolylineGeography>();
+    } else {
       result = absl::make_unique<PolylineGeography>(std::move(polylines_));
       polylines_.clear();
-    } else {
-      result = absl::make_unique<PolylineGeography>();
     }
 
     return std::unique_ptr<Geography>(result.release());
@@ -226,7 +226,7 @@ class PolygonConstructor : public Constructor {
   Result ring_end() {
     finish_points();
 
-    if (points_.size() == 0) {
+    if (points_.empty()) {
       return Result::CONTINUE;
     }
 


### PR DESCRIPTION
See https://releases.llvm.org/5.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/readability-container-size-empty.html