### PR TITLE
Remove redundant .get()

### DIFF
--- a/src/s2geography/constructor.h
+++ b/src/s2geography/constructor.h
@@ -395,7 +395,7 @@ class FeatureConstructor : public CollectionConstructor {
       return absl::make_unique<GeographyCollection>();
     } else {
       std::unique_ptr<Geography> feature = std::move(features_.back());
-      if (feature.get() == nullptr) {
+      if (feature == nullptr) {
         throw Exception("finish_feature() generated nullptr");
       }
 


### PR DESCRIPTION
Unnecessary for "smart" pointers:

https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-smartptr-get.html