### PR TITLE
Patch cord.h to remove CRAN warning

### DIFF
--- a/src/absl/strings/cord.h
+++ b/src/absl/strings/cord.h
@@ -1179,8 +1179,15 @@ inline cord_internal::CordRepFlat* Cord::InlineRep::MakeFlatWithExtraCapacity(
   size_t len = data_.inline_size();
   auto* result = CordRepFlat::New(len + extra);
   result->length = len;
-  memcpy(result->Data(), data_.as_chars(), sizeof(data_));
-  return result;
+  // The following line results in a warning in gcc13 because result->Data()
+  // is a structure that is declared to be 3 bytes in length but is allocated
+  // using C++ trickery such that the following line is safe in a way that
+  // the compiler cannot detect. S2 doesn't use cords anyway, so we just
+  // comment out this line and throw an exception to make sure we don't silently
+  // do the wrong thing.
+  // memcpy(result->Data(), data_.as_chars(), sizeof(data_));
+  throw std::runtime_error(
+    "Cord::InlineRep::MakeFlatWithExtraCapacity() not supported in Abseil as vendored by R/s2");
 }
 
 inline void Cord::InlineRep::EmplaceTree(CordRep* rep,


### PR DESCRIPTION
Closes #223.

This warning is occurring because Abseil does C++ trickery to inline character data into its "cord" data structure. S2 uses the "strings" module from Abseil for its logging and its text format parsing/generation. We explicitly turn off logging and don't use S2's text format and thus the piece of code in question is never called.

This "fix" just comments out the line and throws an exception if for some unforseen reason that method actually actually does get called. In that case the error should propagate up to the top level catch provided by Rcpp.

The real fix is to update Abseil; however, updating Abseil means we can no longer support C++11 (we're using the last version of Abseil that does support C++11; subsequent versions require C++14). That would mean that s2 (and its reverse dependency sf) may have trouble building on Centos 7 (e.g., many compute clusters). Centos 7 isn't EOL until June 2024, so it may be worth considering making s2 an optional dependency of sf instead of a hard one (cc @edzer ). There *is* a workaround (use something called devtoolset 8 which allows using the Centos 8 toolchain to compile stuff for Centos 7).