### PR TITLE
Fix documentation for `k` in `s2_cell_child()`

### DIFF
--- a/R/s2-bounds.R
+++ b/R/s2-bounds.R
@@ -8,7 +8,7 @@
 #' the order of points or polylines. `lng_lo` values larger than `lng_hi` indicate
 #' regions that span the antimeridian, see the Fiji example.
 #'
-#' @inheritParams s2_is_collection
+#' @param x An [s2_geography()] vector.
 #' @export
 #' @return Both functions return a `data.frame`:
 #'

--- a/R/s2-cell.R
+++ b/R/s2-cell.R
@@ -183,7 +183,7 @@ Summary.s2_cell <- function(x, ..., na.rm = FALSE) {
 #'
 #' @param x,y An [s2_cell()] vector
 #' @param level An integer between 0 and 30, inclusive.
-#' @param k An integer between 1 and 4
+#' @param k An integer between 0 and 3
 #' @param radius The radius to use (e.g., [s2_earth_radius_meters()])
 #' @param na.rm Remove NAs prior to computing aggregate?
 #' @export

--- a/man/s2_boundary.Rd
+++ b/man/s2_boundary.Rd
@@ -67,11 +67,7 @@ s2_convex_hull_agg(x, na.rm = FALSE)
 s2_point_on_surface(x, na.rm = FALSE)
 }
 \arguments{
-\item{x}{\link[=as_s2_geography]{geography vectors}. These inputs
-are passed to \code{\link[=as_s2_geography]{as_s2_geography()}}, so you can pass other objects
-(e.g., character vectors of well-known text) directly.}
-
-\item{y}{\link[=as_s2_geography]{geography vectors}. These inputs
+\item{x, y}{\link[=as_s2_geography]{geography vectors}. These inputs
 are passed to \code{\link[=as_s2_geography]{as_s2_geography()}}, so you can pass other objects
 (e.g., character vectors of well-known text) directly.}
 

--- a/man/s2_bounds_cap.Rd
+++ b/man/s2_bounds_cap.Rd
@@ -9,6 +9,9 @@ s2_bounds_cap(x)
 
 s2_bounds_rect(x)
 }
+\arguments{
+\item{x}{An \code{\link[=s2_geography]{s2_geography()}} vector.}
+}
 \value{
 Both functions return a \code{data.frame}:
 \itemize{

--- a/man/s2_bounds_cap.Rd
+++ b/man/s2_bounds_cap.Rd
@@ -9,11 +9,6 @@ s2_bounds_cap(x)
 
 s2_bounds_rect(x)
 }
-\arguments{
-\item{x}{\link[=as_s2_geography]{geography vectors}. These inputs
-are passed to \code{\link[=as_s2_geography]{as_s2_geography()}}, so you can pass other objects
-(e.g., character vectors of well-known text) directly.}
-}
 \value{
 Both functions return a \code{data.frame}:
 \itemize{

--- a/man/s2_cell_is_valid.Rd
+++ b/man/s2_cell_is_valid.Rd
@@ -69,7 +69,7 @@ s2_cell_common_ancestor_level_agg(x, na.rm = FALSE)
 \arguments{
 \item{x, y}{An \code{\link[=s2_cell]{s2_cell()}} vector}
 
-\item{k}{An integer between 1 and 4}
+\item{k}{An integer between 0 and 3}
 
 \item{radius}{The radius to use (e.g., \code{\link[=s2_earth_radius_meters]{s2_earth_radius_meters()}})}
 

--- a/man/s2_contains.Rd
+++ b/man/s2_contains.Rd
@@ -45,11 +45,7 @@ s2_dwithin(x, y, distance, radius = s2_earth_radius_meters())
 s2_prepared_dwithin(x, y, distance, radius = s2_earth_radius_meters())
 }
 \arguments{
-\item{x}{\link[=as_s2_geography]{geography vectors}. These inputs
-are passed to \code{\link[=as_s2_geography]{as_s2_geography()}}, so you can pass other objects
-(e.g., character vectors of well-known text) directly.}
-
-\item{y}{\link[=as_s2_geography]{geography vectors}. These inputs
+\item{x, y}{\link[=as_s2_geography]{geography vectors}. These inputs
 are passed to \code{\link[=as_s2_geography]{as_s2_geography()}}, so you can pass other objects
 (e.g., character vectors of well-known text) directly.}
 

--- a/man/s2_geog_point.Rd
+++ b/man/s2_geog_point.Rd
@@ -79,9 +79,7 @@ be moved to satisfy the planar edge constraint.}
 
 \item{wkb_bytes}{A \code{list()} of \code{raw()}}
 
-\item{x}{\link[=as_s2_geography]{geography vectors}. These inputs
-are passed to \code{\link[=as_s2_geography]{as_s2_geography()}}, so you can pass other objects
-(e.g., character vectors of well-known text) directly.}
+\item{x}{An object that can be converted to an s2_geography vector}
 
 \item{precision}{The number of significant digits to export when
 writing well-known text. If \code{trim = FALSE}, the number of

--- a/man/s2_plot.Rd
+++ b/man/s2_plot.Rd
@@ -25,11 +25,7 @@ for point and multipoint geometries, \code{\link[graphics:lines]{graphics::lines
 and multilinestring geometries, and \code{\link[graphics:polypath]{graphics::polypath()}} for polygon
 and multipolygon geometries.}
 
-\item{asp}{Passed to \code{\link[graphics:plot.default]{graphics::plot()}}}
-
-\item{xlab}{Passed to \code{\link[graphics:plot.default]{graphics::plot()}}}
-
-\item{ylab}{Passed to \code{\link[graphics:plot.default]{graphics::plot()}}}
+\item{asp, xlab, ylab}{Passed to \code{\link[graphics:plot.default]{graphics::plot()}}}
 
 \item{rule}{The rule to use for filling polygons (see \code{\link[graphics:polypath]{graphics::polypath()}})}
 


### PR DESCRIPTION
Closes #225.

I opted to change the documentation: everywhere else we pass values directly to S2 (e.g., level) even though those are 0-indexed, too. This also has the benefit of not breaking any existing usage.