### PR TITLE
Add CXX11 back

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -2,6 +2,8 @@ PKG_CPPFLAGS = -I../src -DSTRICT_R_HEADERS
 PKG_LIBS = @libs@
 PKG_CXXFLAGS = @cflags@ -pthread
 
+CXX_STD = CXX11
+
 ABSL_LIBS = absl/base/internal/cycleclock.o \
     absl/base/internal/low_level_alloc.o \
     absl/base/internal/raw_logging.o \

--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,2 +1,3 @@
 CRT=-ucrt
 include Makevars.win
+CXX_STD = CXX11

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -2,6 +2,8 @@ VERSION = 1.1.1k
 PKG_CPPFLAGS = -DS2_USE_EXACTFLOAT -D_USE_MATH_DEFINES -DNDEBUG -DIS_LITTLE_ENDIAN -DOMIT_STRPTIME -I../windows/openssl-$(VERSION)/include -I../src
 PKG_LIBS = -Ls2 -ls2static -L../windows/openssl-$(VERSION)/lib${R_ARCH}${CRT} -lssl -lcrypto -lws2_32 -lgdi32 -lcrypt32
 
+CXX_STD = CXX11
+
 STATLIB = s2/libs2static.a
 
 ABSL_LIBS = absl/base/internal/cycleclock.o \


### PR DESCRIPTION
For #232...I also have a winbuilder check queued because I realized there wasn't CXX_STD = CXX11 in Makevars.ucrt (this matters for OBJECTS, so maybe it matters for CXX_STD too).