### PR TITLE
Attempt to fix sanitizer error

### DIFF
--- a/src/s2/s2region_coverer.h
+++ b/src/s2/s2region_coverer.h
@@ -248,7 +248,10 @@ class S2RegionCoverer {
  private:
   struct Candidate {
     void* operator new(std::size_t size, std::size_t max_children) {
-      return ::operator new (size + max_children * sizeof(Candidate *));
+      // dd: CRAN reports a sanitizer error when using this magic, so
+      // we just hard code for the maximum size the comments suggest it will be
+      // return ::operator new (size + max_children * sizeof(Candidate *));
+      return ::operator new (size);
     }
 
     void operator delete(void* p) {
@@ -268,7 +271,9 @@ class S2RegionCoverer {
     S2Cell cell;
     bool is_terminal;        // Cell should not be expanded further.
     int num_children = 0;    // Number of children that intersect the region.
-    __extension__ Candidate* children[0];  // Actual size may be 0, 4, 16, or 64 elements.
+    // dd: To avoid a sanitizer, we hard-code 64 here rather than rely on
+    // flexible array member magic.
+    Candidate* children[64];  // Actual size may be 0, 4, 16, or 64 elements.
   };
 
   // If the cell intersects the given region, return a new candidate with no


### PR DESCRIPTION
Closes #236.

This doesn't seem to slow down covering calculations:

``` r
library(s2)

countries <- s2_data_countries()

bench::mark(
  s2_covering_cell_ids(countries, max_cells = 100)
)
#> # A tibble: 1 × 6
#>   expression                                            min   median `itr/sec`
#>   <bch:expr>                                       <bch:tm> <bch:tm>     <dbl>
#> 1 s2_covering_cell_ids(countries, max_cells = 100)    163ms    165ms      6.08
#> # ℹ 2 more variables: mem_alloc <bch:byt>, `gc/sec` <dbl>
```

In theory it allocates more memory during them, but I'm not sure that `64 * sizeof(void*)` - even recursively - is causing much of a problem in its use here.