### PR TITLE
Remove duplicated s2_cell_sentinel() definition

### DIFF
--- a/R/s2-cell.R
+++ b/R/s2-cell.R
@@ -54,12 +54,6 @@ s2_cell_invalid <- function() {
 
 #' @rdname s2_cell
 #' @export
-s2_cell_sentinel <- function() {
-  cpp_s2_cell_sentinel()
-}
-
-#' @rdname s2_cell
-#' @export
 as_s2_cell <- function(x, ...) {
   UseMethod("as_s2_cell")
 }

--- a/man/s2_cell.Rd
+++ b/man/s2_cell.Rd
@@ -9,6 +9,7 @@
 \alias{as_s2_cell.character}
 \alias{as_s2_cell.s2_geography}
 \alias{as_s2_cell.wk_xy}
+\alias{as_s2_cell.integer64}
 \alias{new_s2_cell}
 \title{Create S2 Cell vectors}
 \usage{
@@ -17,8 +18,6 @@ s2_cell(x = character())
 s2_cell_sentinel()
 
 s2_cell_invalid()
-
-s2_cell_sentinel()
 
 as_s2_cell(x, ...)
 
@@ -29,6 +28,8 @@ as_s2_cell(x, ...)
 \method{as_s2_cell}{s2_geography}(x, ...)
 
 \method{as_s2_cell}{wk_xy}(x, ...)
+
+\method{as_s2_cell}{integer64}(x, ...)
 
 new_s2_cell(x)
 }


### PR DESCRIPTION
This PR removes a duplicated `s2_cell_sentinel()` definition. This function is originally defined on line 43-47, then defined (identically) for a second time on 55-60; this PR removes the latter definition.

Re-documenting then removes a duplicate `\alias{s2_cell_sentinel()}` from the man page (and website -- https://r-spatial.github.io/s2/ ). It also added `\method{as_s2_cell}{integer64}(x, ...)`, which seems to be unrelated to this PR, but I left as a change (assuming it's caused by some other changes or package updates).