### PR TITLE
Apply Abseil patch to fix compile on Alpine Linux

### DIFF
--- a/src/absl/base/internal/direct_mmap.h
+++ b/src/absl/base/internal/direct_mmap.h
@@ -72,7 +72,7 @@ namespace base_internal {
 // Platform specific logic extracted from
 // https://chromium.googlesource.com/linux-syscall-support/+/master/linux_syscall_support.h
 inline void* DirectMmap(void* start, size_t length, int prot, int flags, int fd,
-                        off64_t offset) noexcept {
+                        off_t offset) noexcept {
 #if defined(__i386__) || defined(__ARM_ARCH_3__) || defined(__ARM_EABI__) || \
     defined(__m68k__) || defined(__sh__) ||                                  \
     (defined(__hppa__) && !defined(__LP64__)) ||                             \
@@ -101,7 +101,7 @@ inline void* DirectMmap(void* start, size_t length, int prot, int flags, int fd,
 #else
   return reinterpret_cast<void*>(
       syscall(SYS_mmap2, start, length, prot, flags, fd,
-              static_cast<off_t>(offset / pagesize)));
+              static_cast<unsigned long>(offset / pagesize)));
 #endif
 #elif defined(__s390x__)
   // On s390x, mmap() arguments are passed in memory.


### PR DESCRIPTION
Closes #251.

Tested via:

```
# docker run --rm -it -v $(pwd):/s2 alpine:3.19.0
apk add R R-dev g++ linux-headers
R -e "install.packages(c('Rcpp', 'wk'), repos = 'https://cloud.r-project.org/')"
cd /s2 && R CMD INSTALL . --preclean
```

Upstream reference: https://github.com/abseil/abseil-cpp/commit/4500c2fada4e952037c59bd65e8be1ba0b29f21e