### PR TITLE
Use openssl from rtools if available

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,6 +1,14 @@
+OPENSSL_LIBS = $(shell pkg-config --libs openssl)
+
+# Config for legacy rtools without pkgconfig
+ifeq (,$(OPENSSL_LIBS))
+OPENSSL_LIBS=-L../windows/openssl-$(VERSION)/lib${R_ARCH}${CRT} -lssl -lcrypto -lws2_32 -lgdi32 -lcrypt32
+OPENSSL_CFLAGS=-I../windows/openssl-$(VERSION)/include
+endif
+
 VERSION = 1.1.1k
-PKG_CPPFLAGS = -DS2_USE_EXACTFLOAT -D_USE_MATH_DEFINES -DNDEBUG -DIS_LITTLE_ENDIAN -DOMIT_STRPTIME -I../windows/openssl-$(VERSION)/include -I../src
-PKG_LIBS = -Ls2 -ls2static -L../windows/openssl-$(VERSION)/lib${R_ARCH}${CRT} -lssl -lcrypto -lws2_32 -lgdi32 -lcrypt32
+PKG_CPPFLAGS = -DS2_USE_EXACTFLOAT -D_USE_MATH_DEFINES -DNDEBUG -DIS_LITTLE_ENDIAN -DOMIT_STRPTIME $(OPENSSL_CFLAGS) -I../src
+PKG_LIBS = -Ls2 -ls2static $(OPENSSL_LIBS)
 
 CXX_STD = CXX11
 


### PR DESCRIPTION
As per cran policies, this uses the openssl llibs from rtools when available.