### PR TITLE
Fix check warnings identified by r-lib/containers checks

### DIFF
--- a/src/s2/s2region_coverer.h
+++ b/src/s2/s2region_coverer.h
@@ -272,7 +272,7 @@ class S2RegionCoverer {
     S2Cell cell;
     bool is_terminal;        // Cell should not be expanded further.
     int num_children = 0;    // Number of children that intersect the region.
-    Candidate* children[0];  // Actual size may be 0, 4, 16, or 64 elements.
+    __extension__ Candidate* children[0];  // Actual size may be 0, 4, 16, or 64 elements.
   };
 
   // If the cell intersects the given region, return a new candidate with no


### PR DESCRIPTION
- Apply the `__extension__ Candidate* children[0];  // Actual size may be 0, 4, 16, or 64 elements.` fix from the previous vendor of s2.