### PR TITLE
Increase tolerance to accommodate small inaccuracies in sin().

### DIFF
--- a/tests/testthat/test-s2-transformers.R
+++ b/tests/testthat/test-s2-transformers.R
@@ -473,7 +473,7 @@ test_that("s2_snap_to_grid() works", {
 test_that("s2_buffer() works", {
   # create a hemisphere!
   ply <- s2_buffer_cells("POINT (0 0)", distance = pi / 2, radius = 1)
-  expect_near(s2_area(ply, radius = 1), 4 * pi / 2, epsilon = 0.1)
+  expect_near(s2_area(ply, radius = 1), 4 * pi / 2, epsilon = 0.2)
 })
 
 test_that("s2_simplify() works", {


### PR DESCRIPTION
Unfortunately the package does not pass its tests with mingw-w64 v12 on Windows. Rtools45 still uses mingw-w64 v11 to allow time for packages to be fixed, so one needs to use an unreleased version to see this.

The problem is that v12 decided to switch many C math functions to UCRT from previously used internal implementation. In case of s2, the failure is caused by very small inaccuracies in `sin()` - they are within 1 ULP, so programs should be able to work with that (the C standard doesn't give any limits to accuracy of math functions).

The failure is:

```
  ── Failure ('test-s2-transformers.R:476:3'): s2_buffer() works ─────────────────
  abs(y - x) < epsilon is not TRUE

  `actual`:   FALSE
  `expected`: TRUE 
  Backtrace:
      ▆
   1. └─s2:::expect_near(s2_area(ply, radius = 1), 4 * pi/2, epsilon = 0.1) at test-s2-transformers.R:476:3
   2.   └─testthat::expect_true(abs(y - x) < epsilon)
```

And it involves just two calls to `sin()` with a 1 ULP inaccuracy, the arguments are `0x1.921fb54442d18p-1` and `0x1.fca6ddd4ae7b0p-1`. The internal implementation of mingw-w64 v11 provided a precise (correctly rounded) resullt for these.

The result I see with v12 on this extracted example

```
  library(s2)
  ply <- s2_buffer_cells("POINT (0 0)", distance = pi / 2, radius = 1)
  x <- s2_area(ply, radius = 1)
  y <- 4 * pi / 2
  abs(y - x)
```

is `0.1196702`. With v11, it was `0`.
