### PR TITLE
Implement serialization support for s2_geometry vectors

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -61,6 +61,10 @@ cpp_s2_max_distance <- function(geog1, geog2) {
     .Call(`_s2_cpp_s2_max_distance`, geog1, geog2)
 }
 
+new_s2_geography <- function(data) {
+    .Call(`_s2_new_s2_geography`, data)
+}
+
 cpp_s2_bounds_cap <- function(geog) {
     .Call(`_s2_cpp_s2_bounds_cap`, geog)
 }

--- a/R/s2-geography.R
+++ b/R/s2-geography.R
@@ -179,9 +179,6 @@ wk_set_geodesic.s2_geography <- function(x, geodesic) {
   x
 }
 
-new_s2_geography <- function(x) {
-  structure(x, class = c("s2_geography", "wk_vctr"))
-}
 
 #' @export
 is.na.s2_geography <- function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -86,3 +86,7 @@ expect_wkt_equal <- function(x, y, precision = 16) {
 expect_near <- function(x, y, epsilon) {
   testthat::expect_true(abs(y - x) < epsilon)
 }
+
+expect_wkt_serializeable <- function(x) {
+  expect_wkt_equal(x, unserialize(serialize(x, NULL)), precision = 8)
+}

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -106,6 +106,7 @@ S2_OBJECTS = s2/encoded_s2cell_id_vector.o \
 STATLIB = s2/libs2static.a
 
 OBJECTS = cpp-compat.o \
+     s2-altrep.o \
      s2-accessors.o \
      s2-bounds.o \
      s2-cell.o \

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -176,6 +176,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// new_s2_geography
+SEXP new_s2_geography(SEXP data);
+RcppExport SEXP _s2_new_s2_geography(SEXP dataSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type data(dataSEXP);
+    rcpp_result_gen = Rcpp::wrap(new_s2_geography(data));
+    return rcpp_result_gen;
+END_RCPP
+}
 // cpp_s2_bounds_cap
 DataFrame cpp_s2_bounds_cap(List geog);
 RcppExport SEXP _s2_cpp_s2_bounds_cap(SEXP geogSEXP) {
@@ -470,7 +481,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // cpp_s2_cell_center
-List cpp_s2_cell_center(NumericVector cellIdVector);
+SEXP cpp_s2_cell_center(NumericVector cellIdVector);
 RcppExport SEXP _s2_cpp_s2_cell_center(SEXP cellIdVectorSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -481,7 +492,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // cpp_s2_cell_polygon
-List cpp_s2_cell_polygon(NumericVector cellIdVector);
+SEXP cpp_s2_cell_polygon(NumericVector cellIdVector);
 RcppExport SEXP _s2_cpp_s2_cell_polygon(SEXP cellIdVectorSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -492,7 +503,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // cpp_s2_cell_vertex
-List cpp_s2_cell_vertex(NumericVector cellIdVector, IntegerVector k);
+SEXP cpp_s2_cell_vertex(NumericVector cellIdVector, IntegerVector k);
 RcppExport SEXP _s2_cpp_s2_cell_vertex(SEXP cellIdVectorSEXP, SEXP kSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -1369,6 +1380,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_s2_cpp_s2_project_normalized", (DL_FUNC) &_s2_cpp_s2_project_normalized, 2},
     {"_s2_cpp_s2_distance", (DL_FUNC) &_s2_cpp_s2_distance, 2},
     {"_s2_cpp_s2_max_distance", (DL_FUNC) &_s2_cpp_s2_max_distance, 2},
+    {"_s2_new_s2_geography", (DL_FUNC) &_s2_new_s2_geography, 1},
     {"_s2_cpp_s2_bounds_cap", (DL_FUNC) &_s2_cpp_s2_bounds_cap, 1},
     {"_s2_cpp_s2_bounds_rect", (DL_FUNC) &_s2_cpp_s2_bounds_rect, 1},
     {"_s2_cpp_s2_cell_union_normalize", (DL_FUNC) &_s2_cpp_s2_cell_union_normalize, 1},
@@ -1476,7 +1488,9 @@ static const R_CallMethodDef CallEntries[] = {
     {NULL, NULL, 0}
 };
 
+void altrep_init(DllInfo *dll);
 RcppExport void R_init_s2(DllInfo *dll) {
     R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
     R_useDynamicSymbols(dll, FALSE);
+    altrep_init(dll);
 }

--- a/src/geography.h
+++ b/src/geography.h
@@ -6,6 +6,8 @@
 
 #include "s2geography.h"
 
+SEXP new_s2_geography(SEXP data);
+
 class RGeography {
 public:
   RGeography(std::unique_ptr<s2geography::Geography> geog):

--- a/src/s2-altrep.cpp
+++ b/src/s2-altrep.cpp
@@ -1,0 +1,62 @@
+#define R_NO_REMAP
+#include <R.h>
+#include <Rinternals.h>
+#include "R_ext/Altrep.h"
+
+#include <Rcpp.h>
+using namespace Rcpp;
+
+R_altrep_class_t s2_geography_altrep_cls;
+
+// [[Rcpp::export]]
+SEXP new_s2_geography(SEXP data) {
+  if (TYPEOF(data) != VECSXP) {
+    Rf_error("s2_geography data must be a list");
+  }
+
+  SEXP obj = PROTECT(R_new_altrep(s2_geography_altrep_cls, data, R_NilValue));
+
+  SEXP cls = PROTECT(Rf_allocVector(STRSXP, 2));
+  SET_STRING_ELT(cls, 0, Rf_mkChar("s2_geography"));
+  SET_STRING_ELT(cls, 1, Rf_mkChar("wk_vctr"));
+
+  Rf_setAttrib(obj, R_ClassSymbol, cls);
+  UNPROTECT(2);
+
+  return obj;
+}
+
+// ALTREP implementation for s2_geography
+static R_INLINE R_xlen_t s2_altrep_Length(SEXP obj) {
+  SEXP data = R_altrep_data1(obj);
+  return Rf_xlength(data);
+}
+
+static SEXP s2_altrep_Elt(SEXP obj, R_xlen_t i) {
+  SEXP data = R_altrep_data1(obj);
+  return VECTOR_ELT(data, i);
+}
+
+static SEXP s2_altrep_Serialized_state(SEXP obj)
+{
+  Function to_wkb = Environment::namespace_env("s2")["s2_as_binary"];
+
+  return to_wkb(obj);
+}
+
+static SEXP s2_altrep_Unserialize(SEXP cls, SEXP state)
+{
+  Function from_wkb = Environment::namespace_env("s2")["s2_geog_from_wkb"];
+
+  return from_wkb(state);
+}
+
+// [[Rcpp::init]]
+void altrep_init(DllInfo *dll) {
+  s2_geography_altrep_cls = R_make_altlist_class("s2_geography", "s2", dll);
+
+  R_set_altrep_Length_method(s2_geography_altrep_cls, s2_altrep_Length);
+  R_set_altlist_Elt_method(s2_geography_altrep_cls, s2_altrep_Elt);
+  R_set_altrep_Serialized_state_method(s2_geography_altrep_cls, s2_altrep_Serialized_state);
+  R_set_altrep_Unserialize_method(s2_geography_altrep_cls, s2_altrep_Unserialize);
+};

--- a/src/s2-cell.cpp
+++ b/src/s2-cell.cpp
@@ -350,7 +350,7 @@ LogicalVector cpp_s2_cell_is_valid(NumericVector cellIdVector) {
 }
 
 // [[Rcpp::export]]
-List cpp_s2_cell_center(NumericVector cellIdVector) {
+SEXP cpp_s2_cell_center(NumericVector cellIdVector) {
   class Op: public UnaryS2CellOperator<List, SEXP> {
     SEXP processCell(S2CellId cellId, R_xlen_t i) {
       if (cellId.is_valid()) {
@@ -363,12 +363,11 @@ List cpp_s2_cell_center(NumericVector cellIdVector) {
 
   Op op;
   List result = op.processVector(cellIdVector);
-  result.attr("class") = CharacterVector::create("s2_geography", "wk_vctr");
-  return result;
+  return new_s2_geography(result);
 }
 
 // [[Rcpp::export]]
-List cpp_s2_cell_polygon(NumericVector cellIdVector) {
+SEXP cpp_s2_cell_polygon(NumericVector cellIdVector) {
   class Op: public UnaryS2CellOperator<List, SEXP> {
     SEXP processCell(S2CellId cellId, R_xlen_t i) {
       if (cellId.is_valid()) {
@@ -382,12 +381,11 @@ List cpp_s2_cell_polygon(NumericVector cellIdVector) {
 
   Op op;
   List result = op.processVector(cellIdVector);
-  result.attr("class") = CharacterVector::create("s2_geography", "wk_vctr");
-  return result;
+  return new_s2_geography(result);
 }
 
 // [[Rcpp::export]]
-List cpp_s2_cell_vertex(NumericVector cellIdVector, IntegerVector k) {
+SEXP cpp_s2_cell_vertex(NumericVector cellIdVector, IntegerVector k) {
   class Op: public UnaryS2CellOperator<List, SEXP> {
     SEXP processCell(S2CellId cellId, R_xlen_t i) {
       if (cellId.is_valid() && (this->k[i] >= 0)) {
@@ -404,8 +402,7 @@ List cpp_s2_cell_vertex(NumericVector cellIdVector, IntegerVector k) {
   Op op;
   op.k = k;
   List result = op.processVector(cellIdVector);
-  result.attr("class") = CharacterVector::create("s2_geography", "wk_vctr");
-  return result;
+  return new_s2_geography(result);
 }
 
 // [[Rcpp::export]]

--- a/src/s2-constructors-formatters.cpp
+++ b/src/s2-constructors-formatters.cpp
@@ -109,12 +109,8 @@ int builder_vector_start(const wk_vector_meta_t* meta, void* handler_data) {
 SEXP builder_vector_end(const wk_vector_meta_t* meta, void* handler_data) {
   builder_handler_t* data = (builder_handler_t*) handler_data;
   builder_result_finalize(data);
-  SEXP cls = PROTECT(Rf_allocVector(STRSXP, 2));
-  SET_STRING_ELT(cls, 0, Rf_mkChar("s2_geography"));
-  SET_STRING_ELT(cls, 1, Rf_mkChar("wk_vctr"));
-  Rf_setAttrib(data->result, R_ClassSymbol, cls);
-  UNPROTECT(1);
-  return data->result;
+
+  return new_s2_geography(data->result);
 }
 
 int builder_feature_start(const wk_vector_meta_t* meta, R_xlen_t feat_id, void* handler_data) {

--- a/src/s2-new-geography.h
+++ b/src/s2-new-geography.h
@@ -1,0 +1,3 @@
+#pragma once
+
+SEXP new_s2_geography(SEXP data);

--- a/tests/testthat/test-s2-constructors-formatters.R
+++ b/tests/testthat/test-s2-constructors-formatters.R
@@ -198,12 +198,3 @@ test_that("planar = TRUE works for s2_geog_from_text()", {
   out <- s2_as_binary(geog, planar = TRUE)
   expect_true(s2_num_points(out) > s2_num_points(geog))
 })
-
-test_that("null external pointers do not crash in the handler", {
-  geog <- as_s2_geography("POINT (0 1)")
-  geog2 <- unserialize(serialize(geog, NULL))
-  expect_error(
-    wk::wk_void(geog2),
-    "External pointer is not valid"
-  )
-})

--- a/tests/testthat/test-s2-serialization.R
+++ b/tests/testthat/test-s2-serialization.R
@@ -1,0 +1,189 @@
+# S2 Geography constructors
+test_that("s2_geography() can be correctly serialized", {
+  expect_wkt_serializeable(s2_geography())
+})
+
+test_that("s2_geog_point() can be correctly serialized", {
+  expect_wkt_serializeable(s2_geog_point(
+    -64, 45
+  ))
+})
+
+test_that("s2_make_line() can be correctly serialized", {
+  expect_wkt_serializeable(s2_make_line(
+    c(-64, 8), c(45, 71)
+  ))
+})
+
+test_that("s2_make_polygon() can be correctly serialized", {
+  expect_wkt_serializeable(s2_make_polygon(
+    c(-45, 8, 0), c(64, 71, 90)
+  ))
+  expect_wkt_serializeable(s2_make_polygon(
+    c(-45, 8, 0, -45), c(64, 71, 90, 64)
+  ))
+})
+
+test_that("s2_geog_from_wkt() can be correctly serialized", {
+  expect_wkt_serializeable(s2_geog_from_text(
+    "POINT (-64 45)"
+  ))
+})
+
+test_that("s2_geog_from_wkb() can be correctly serialized", {
+  expect_wkt_serializeable(s2_geog_from_wkb(
+    as_wkb("POINT (-64 45)")
+  ))
+})
+
+# Geography Transformations
+test_that("s2_union() can be correctly serialized", {
+  expect_wkt_serializeable(s2_union(
+    "POINT (10 30)",
+    "POINT (30 10)"
+  ))
+})
+
+test_that("s2_intersection() can be correctly serialized", {
+  expect_wkt_serializeable(s2_intersection(
+    "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))",
+    "POLYGON ((5 5, 15 5, 15 15, 5 15, 5 5))",
+  ))
+})
+
+
+test_that("s2_difference() can be correctly serialized", {
+  expect_wkt_serializeable(s2_difference(
+    "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))",
+    "POLYGON ((5 5, 15 5, 15 15, 5 15, 5 5))",
+  ))
+})
+
+test_that("s2_sym_difference() can be correctly serialized", {
+  expect_wkt_serializeable(s2_sym_difference(
+    "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))",
+    "POLYGON ((5 5, 15 5, 15 15, 5 15, 5 5))",
+  ))
+})
+
+test_that("s2_convex_hull() can be correctly serialized", {
+  expect_wkt_serializeable(s2_convex_hull(
+    "GEOMETRYCOLLECTION (POINT (-1 0), POINT (0 1), POINT (1 0))"
+  ))
+})
+
+test_that("s2_boundary() can be correctly serialized", {
+  expect_wkt_serializeable(s2_boundary(
+    "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"
+  ))
+})
+
+
+test_that("s2_centroid() can be correctly serialized", {
+  expect_wkt_serializeable(s2_centroid(
+    "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"
+  ))
+})
+
+test_that("s2_closest_point() can be correctly serialized", {
+  expect_wkt_serializeable(s2_closest_point(
+    "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))",
+    "POINT (-63 46)"
+  ))
+})
+
+test_that("s2_minimum_clearance_line_between() can be correctly serialized", {
+  expect_wkt_serializeable(s2_minimum_clearance_line_between(
+    "POINT (10 30)",
+    "POINT (30 10)"
+  ))
+})
+
+test_that("s2_snap_to_grid() can be correctly serialized", {
+  expect_wkt_serializeable(s2_snap_to_grid(
+    "POINT (10.25 30.5)",
+    1
+  ))
+})
+
+test_that("s2_simplify() can be correctly serialized", {
+  expect_wkt_serializeable(s2_simplify(
+    "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))",
+    1
+  ))
+})
+
+test_that("s2_rebuild() can be correctly serialized", {
+  expect_wkt_serializeable(s2_rebuild(
+    "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"
+  ))
+})
+
+test_that("s2_buffer_cells() can be correctly serialized", {
+  expect_wkt_serializeable(s2_buffer_cells(
+    "POINT (10 10)", 100
+  ))
+})
+
+test_that("s2_centroid_agg() can be correctly serialized", {
+  expect_wkt_serializeable(s2_centroid_agg(c(
+    "POINT (-1 0)",
+    "POINT (0 1)",
+    "POINT (1 0)"
+  )))
+})
+
+test_that("s2_coverage_union_agg() can be correctly serialized", {
+  expect_wkt_serializeable(s2_coverage_union_agg(c(
+    "POINT (-1 0)",
+    "POINT (0 1)",
+    "POINT (1 0)"
+  )))
+})
+
+test_that("s2_rebuild_agg() can be correctly serialized", {
+  expect_wkt_serializeable(s2_rebuild_agg(c(
+    "POINT (-1 0)",
+    "POINT (0 1)",
+    "POINT (1 0)"
+  )))
+})
+
+test_that("s2_union_agg() can be correctly serialized", {
+  expect_wkt_serializeable(s2_union_agg(c(
+    "POINT (-1 0)",
+    "POINT (0 1)",
+    "POINT (1 0)"
+  )))
+})
+
+test_that("s2_convex_hull_agg() can be correctly serialized", {
+  expect_wkt_serializeable(s2_convex_hull_agg(c(
+    "POINT (-1 0)",
+    "POINT (0 1)",
+    "POINT (1 0)"
+  )))
+})
+
+test_that("s2_point_on_surface() can be correctly serialized", {
+  expect_wkt_serializeable(s2_point_on_surface(
+    "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"
+  ))
+})
+
+# S2 cell operators that construct s2 geography
+test_that("s2_cell_center() can be correctly serialized", {
+  expect_wkt_serializeable(s2_cell_center(s2_cell("5")))
+})
+
+test_that("s2_cell_boundary() can be correctly serialized", {
+  expect_wkt_serializeable(s2_cell_boundary(s2_cell("5")))
+})
+
+test_that("s2_cell_polygon() can be correctly serialized", {
+  expect_wkt_serializeable(s2_cell_polygon(s2_cell("5")))
+})
+
+test_that("s2_cell_vertex() can be correctly serialized", {
+  expect_wkt_serializeable(s2_cell_vertex(s2_cell("5"), seq_len(4L)))
+})


### PR DESCRIPTION
This patch implements initial serialization support for `s2_geometry` data (#281). The main idea is to make `s2_geometry` objects  a lightweight ALTREP wrapper and provide serialization methods that delegate to WKB conversion routines. Other required ALTREP functionality is delegated to the wrapped features list with no change in behavior. These changes are transparent to the rest of the package since ALTREP vectors behave identically to regular vectors, so pretty much everything works as usual. 

The only required change to existing code was making sure that the constructed objects are correctly initialized. I have found several sites where `s2_geometry` objects were formally constructed (in `builder_vector_end()`, `new_s2_geography()`, and several functions in `s2-cell.cpp`). To streamline this, I have implemented  `new_s2_geography()` at C level and updated all relevant sites to use it as a dedicated constructor for s2 geometry objects. 

All tests are passing on my machine (Apple Silicon on macOS), and I have added a bunch of test to ensure that outputs of all relevant functions can be serialized. I have also tested this build with `sf` (no issues found), as well as on a large internal pipeline that extensively uses `s2` to process spherical geometry - again, no issues. Previously I had to disable caching as it would crash the pipeline (lack of serialization), but now everything works. 

The main caveat of the current implementation is that it does not guarantee to reconstruct the data exactly. I am observing small numerical differences when handling complex geometry. This seems to be an artifact of the data conversion from and to WKB.  