### PR TITLE
Add mention of serializations support to NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # s2 (development version)
 
+* Implement serialization support for `s2_geography` vectors. This not only 
+  allows data containing s2 geography to be safely saved and restored across 
+  R sessions, but also enables using `s2` in parallel algorithms such as 
+  `mclapply()` (#283)
 * Fix code to help gcc-ubsan understand the region coverer (#275)
 * Inspect `S2_FORCE_BUNDLED_ABSEIL` in `conifigure`: if non-empty, any system
   install of Abseil is ignored (e.g., if using a non-standard compiler on a


### PR DESCRIPTION
Added the mention of serialization support to NEWS.md

I also explicitly mention the other big reason for having it in the first place — sending data across forks and  cluster sessions for parallel processing.