### PR TITLE
Add the Dataptr* methods to ALTREP representation

### DIFF
--- a/src/s2-altrep.cpp
+++ b/src/s2-altrep.cpp
@@ -28,7 +28,8 @@ static void s2_altrep_SetElt(SEXP obj, R_xlen_t i, SEXP v) {
 }
 
 static void* s2_altrep_Dataptr(SEXP obj, Rboolean writable) {
-  if (writable) return NULL;
+  if (writable) Rf_error("unable to produce writable DATAPTR for list data");
+
   SEXP data = R_altrep_data1(obj);
   return (void*) DATAPTR_RO(data);
 }

--- a/tests/testthat/test-s2-geography.R
+++ b/tests/testthat/test-s2-geography.R
@@ -284,9 +284,9 @@ test_that("s2_geography vectors support elementwise assignment", {
 })
 
 test_that("DATAPTR can be obtained for s2_geography", {
-  Rcpp::cppFunction("double get_dataptr(SEXP obj) {
-    return (double) ((uintptr_t) DATAPTR_RO(obj));
+  Rcpp::cppFunction("bool get_dataptr(SEXP obj) {
+    return DATAPTR_RO(obj) != NULL;
   }")
 
-  expect_no_error(get_dataptr(as_s2_geography("POINT (0 0)")))
+  expect_true(get_dataptr(as_s2_geography("POINT (0 0)")))
 })


### PR DESCRIPTION
When processing large amounts on data using the `parallel` package, the session occasionally errors out complaining about missing Dataptr method. It is not easily reproducible, and happens during the collection phase. This patch adds the missing methods. 