### PR TITLE
Add missing cstdint include for gcc15

### DIFF
--- a/tools/vendor/abseil-cpp/absl/container/internal/container_memory.h
+++ b/tools/vendor/abseil-cpp/absl/container/internal/container_memory.h
@@ -23,6 +23,7 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <cstdint>
 
 #include "absl/base/config.h"
 #include "absl/memory/memory.h"


### PR DESCRIPTION
`s2` is failing to build on a Ubuntu 25.10 system with gcc 15.2, as the `cstdint` header is no longer transitively included by other headers:

```
[ 69%] Building CXX object absl/flags/CMakeFiles/flags_reflection.dir/reflection.cc.o
In file included from /usr/include/c++/15/cassert:46,
                 from /tmp/RtmpYafy8t/R.INSTALL3700a7df5279d/s2/tools/vendor/abseil-cpp/absl/container/internal/container_memory.h:18,
                 from /tmp/RtmpYafy8t/R.INSTALL3700a7df5279d/s2/tools/vendor/abseil-cpp/absl/container/flat_hash_map.h:40,
                 from /tmp/RtmpYafy8t/R.INSTALL3700a7df5279d/s2/tools/vendor/abseil-cpp/absl/flags/reflection.h:29,
                 from /tmp/RtmpYafy8t/R.INSTALL3700a7df5279d/s2/tools/vendor/abseil-cpp/absl/flags/reflection.cc:16:
/tmp/RtmpYafy8t/R.INSTALL3700a7df5279d/s2/tools/vendor/abseil-cpp/absl/container/internal/container_memory.h: In function ‘void* absl::s2_lts_20230802::container_internal::Allocate(Alloc*, size_t)’:
/tmp/RtmpYafy8t/R.INSTALL3700a7df5279d/s2/tools/vendor/abseil-cpp/absl/container/internal/container_memory.h:66:27: error: ‘uintptr_t’ does not name a type [-Wtemplate-body]
   66 |   assert(reinterpret_cast<uintptr_t>(p) % Alignment == 0 &&
      |                           ^~~~~~~~~
/tmp/RtmpYafy8t/R.INSTALL3700a7df5279d/s2/tools/vendor/abseil-cpp/absl/container/internal/container_memory.h:31:1: note: ‘uintptr_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   30 | #include "absl/utility/utility.h"
  +++ |+#include <cstdint>
   31 | 
make[2]: *** [absl/flags/CMakeFiles/flags_reflection.dir/build.make:79: absl/flags/CMakeFiles/flags_reflection.dir/reflection.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2822: absl/flags/CMakeFiles/flags_reflection.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```