### PR TITLE
Silence CMD check warning in CI when using bundled Abseil and fix windows printf warnings

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,8 +41,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # TODO: Solve Abseil linking issue on R 4.0 and R 4.1/Windows
-          # - {os: windows-latest, r: '4.1'}
           - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: '4.2'}
           - {os: windows-latest, r: '4.3'}
@@ -71,10 +69,13 @@ jobs:
         run: |
           brew install abseil
 
-      - name: Set Makevars (Ubuntu)
+      - name: Set Makevars and environment (Ubuntu)
         if: matrix.config.os == 'ubuntu-latest'
         run: |
           mkdir ~/.R && echo "MAKEFLAGS = -j$(nproc)" > ~/.R/Makevars
+          # Explicitly force bundled Abseil here to avoid CMD check warning
+          # about disallowed symbols in Abseil static libraries
+          echo "S2_FORCE_BUNDLED_ABSEIL=true" >> $GITHUB_ENV
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/configure
+++ b/configure
@@ -79,7 +79,16 @@ if [ -z "$S2_FORCE_BUNDLED_ABSEIL" ] && pkg-config absl_s2 --libs >/dev/null 2>/
   R_S2_ABSL_HOME=""
 else
   echo "** Building abseil-cpp using cmake"
-  CMAKE_INSTALL_PREFIX="/tmp/s2_absl_$$"
+
+  # If the build has explicitly forced building bundled Abseil, we install to a temporary
+  # directory so that R CMD check does not inspects its static libraries for disallowed
+  # symbols. Otherwise, we install into the package source (more conventional).
+  if [ ! -z "$S2_FORCE_BUNDLED_ABSEIL" ]; then
+    CMAKE_INSTALL_PREFIX="/tmp/s2_absl_$$"
+  else
+    CMAKE_INSTALL_PREFIX="`pwd`/tools/dist"
+  fi
+
   mkdir -p "${CMAKE_INSTALL_PREFIX}"
   if tools/build_absl.sh "${CMAKE_INSTALL_PREFIX}"; then
     echo "** Done!"

--- a/configure
+++ b/configure
@@ -76,9 +76,11 @@ if [ -z "$S2_FORCE_BUNDLED_ABSEIL" ] && pkg-config absl_s2 --libs >/dev/null 2>/
   PKGCONFIG_LIBS=`pkg-config --libs absl_s2`
   PKG_CFLAGS="${PKGCONFIG_CFLAGS} ${PKG_CFLAGS}"
   PKG_LIBS="${PKGCONFIG_LIBS} ${PKG_LIBS}"
+  R_S2_ABSL_HOME=""
 else
   echo "** Building abseil-cpp using cmake"
-  CMAKE_INSTALL_PREFIX="`pwd`/tools/dist"
+  CMAKE_INSTALL_PREFIX="/tmp/s2_absl_$$"
+  mkdir -p "${CMAKE_INSTALL_PREFIX}"
   if tools/build_absl.sh "${CMAKE_INSTALL_PREFIX}"; then
     echo "** Done!"
   else
@@ -96,9 +98,9 @@ else
   rm -rf tools/build
 
   # Depending on the cmake options this can end up in a subdirectory of lib
-  ABSL_BASE_PC=`find tools/dist -name absl_base.pc`
+  ABSL_BASE_PC=`find "${CMAKE_INSTALL_PREFIX}" -name absl_base.pc`
   R_S2_PKG_CONFIG_PATH=`dirname "${ABSL_BASE_PC}"`
-  R_S2_ABSL_HOME="`pwd`/tools/dist"
+  R_S2_ABSL_HOME="${CMAKE_INSTALL_PREFIX}"
   export PKG_CONFIG_PATH="${R_S2_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}"
   echo "** Using PKG_CONFIG_PATH=${PKG_CONFIG_PATH}"
   PKGCONFIG_LIBS=`pkg-config --libs absl_s2`
@@ -138,7 +140,7 @@ echo "Using PKG_LIBS=$PKG_LIBS"
 echo "Using PKG_CFLAGS=$PKG_CFLAGS"
 
 # Write to Makevars
-sed -e "s|@cflags@|$PKG_CFLAGS|" -e "s|@libs@|$PKG_LIBS|" src/Makevars.in > src/Makevars
+sed -e "s|@cflags@|$PKG_CFLAGS|" -e "s|@libs@|$PKG_LIBS|" -e "s|@absl_home@|$R_S2_ABSL_HOME|" src/Makevars.in > src/Makevars
 
 # Success
 exit 0

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -138,7 +138,7 @@ $(STATLIB): $(S2_OBJECTS)
 all: $(SHLIB) purify
 
 purify: $(SHLIB)
-	@rm -f $(STATLIB) $(S2_OBJECTS) || true
+	@rm -rf @absl_home@ || true
 
 clean:
 	rm -f $(SHLIB) $(STATLIB) $(OBJECTS) $(S2LIBS)

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -135,7 +135,12 @@ $(SHLIB): $(STATLIB)
 $(STATLIB): $(S2_OBJECTS)
 	ar rcs $(STATLIB) $(S2_OBJECTS)
 
+all: $(SHLIB) purify
+
+purify: $(SHLIB)
+	@rm -f $(STATLIB) $(S2_OBJECTS) || true
+
 clean:
 	rm -f $(SHLIB) $(STATLIB) $(OBJECTS) $(S2LIBS)
 
-.PHONY: clean
+.PHONY: clean purify

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -135,12 +135,7 @@ $(SHLIB): $(STATLIB)
 $(STATLIB): $(S2_OBJECTS)
 	ar rcs $(STATLIB) $(S2_OBJECTS)
 
-all: $(SHLIB) purify
-
-purify: $(SHLIB)
-	@rm -f $(STATLIB) $(S2_OBJECTS) || true
-
 clean:
 	rm -f $(SHLIB) $(STATLIB) $(OBJECTS) $(S2LIBS)
 
-.PHONY: clean purify
+.PHONY: clean

--- a/tools/vendor/abseil-cpp/absl/base/attributes.h
+++ b/tools/vendor/abseil-cpp/absl/base/attributes.h
@@ -84,10 +84,19 @@
 // have an implicit 'this' argument, the arguments of such methods
 // should be counted from two, not one."
 #if ABSL_HAVE_ATTRIBUTE(format) || (defined(__GNUC__) && !defined(__clang__))
+// If using mingw's c99-compliant printf, we need a different format-checking
+// attribute to properly recognize %llu, %llx, etc.
+#if defined(__USE_MINGW_ANSI_STDIO) && defined(__MINGW_PRINTF_FORMAT)
+#define ABSL_PRINTF_ATTRIBUTE(string_index, first_to_check) \
+  __attribute__((__format__(__MINGW_PRINTF_FORMAT, string_index, first_to_check)))
+#define ABSL_SCANF_ATTRIBUTE(string_index, first_to_check) \
+  __attribute__((__format__(__MINGW_SCANF_FORMAT, string_index, first_to_check)))
+#else
 #define ABSL_PRINTF_ATTRIBUTE(string_index, first_to_check) \
   __attribute__((__format__(__printf__, string_index, first_to_check)))
 #define ABSL_SCANF_ATTRIBUTE(string_index, first_to_check) \
   __attribute__((__format__(__scanf__, string_index, first_to_check)))
+#endif
 #else
 #define ABSL_PRINTF_ATTRIBUTE(string_index, first_to_check)
 #define ABSL_SCANF_ATTRIBUTE(string_index, first_to_check)

--- a/tools/vendor/abseil-cpp/absl/base/attributes.h
+++ b/tools/vendor/abseil-cpp/absl/base/attributes.h
@@ -91,6 +91,13 @@
   __attribute__((__format__(__MINGW_PRINTF_FORMAT, string_index, first_to_check)))
 #define ABSL_SCANF_ATTRIBUTE(string_index, first_to_check) \
   __attribute__((__format__(__MINGW_SCANF_FORMAT, string_index, first_to_check)))
+#elif defined(__USE_MINGW_ANSI_STDIO)
+// MinGW ANSI stdio is in use but __MINGW_PRINTF_FORMAT is not defined (older
+// headers). Use gnu_printf which also understands C99 format specifiers.
+#define ABSL_PRINTF_ATTRIBUTE(string_index, first_to_check) \
+  __attribute__((__format__(__gnu_printf__, string_index, first_to_check)))
+#define ABSL_SCANF_ATTRIBUTE(string_index, first_to_check) \
+  __attribute__((__format__(__gnu_scanf__, string_index, first_to_check)))
 #else
 #define ABSL_PRINTF_ATTRIBUTE(string_index, first_to_check) \
   __attribute__((__format__(__printf__, string_index, first_to_check)))


### PR DESCRIPTION
This PR fixes two CMD check issues in our CI:

- In R 4.2 we need to update the printf attribute due to a (long since fixed) mingw bug
- When building using the bundled abseil (e.g., ubuntu), we can silence the warnings about the symbols from Abseil by building it outside the package source tree. I am not sure if CRAN frowns upon this or not but they seem to be ignoring the warning themselves and maybe this saves them some work. I've put this behind the opt-in `S2_FORCE_BUNDLED_ABSEIL` environment variable (so that it doesn't seem sneaky but we/they can get this behaviour to make our checks happy again)