### PR TITLE
Update default force build Abseil to true

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -73,9 +73,6 @@ jobs:
         if: matrix.config.os == 'ubuntu-latest'
         run: |
           mkdir ~/.R && echo "MAKEFLAGS = -j$(nproc)" > ~/.R/Makevars
-          # Explicitly force bundled Abseil here to avoid CMD check warning
-          # about disallowed symbols in Abseil static libraries
-          echo "S2_FORCE_BUNDLED_ABSEIL=true" >> $GITHUB_ENV
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/configure
+++ b/configure
@@ -69,7 +69,11 @@ export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:`pwd`/tools/pkgconfig"
 
 echo "** Using PKG_CONFIG_PATH=${PKG_CONFIG_PATH}"
 
-if [ -z "$S2_FORCE_BUNDLED_ABSEIL" ] && pkg-config absl_s2 --libs >/dev/null 2>/dev/null; then
+if [ -z "$S2_FORCE_BUNDLED_ABSEIL" ]; then
+  S2_FORCE_BUNDLED_ABSEIL=true
+fi
+
+if [ "$S2_FORCE_BUNDLED_ABSEIL" = "false" ] && pkg-config absl_s2 --libs >/dev/null 2>/dev/null; then
   echo "** Using abseil-cpp from pkg-config"
 
   PKGCONFIG_CFLAGS=`pkg-config --cflags-only-I absl_s2`
@@ -83,7 +87,7 @@ else
   # If the build has explicitly forced building bundled Abseil, we install to a temporary
   # directory so that R CMD check does not inspects its static libraries for disallowed
   # symbols. Otherwise, we install into the package source (more conventional).
-  if [ ! -z "$S2_FORCE_BUNDLED_ABSEIL" ]; then
+  if [ "$S2_FORCE_BUNDLED_ABSEIL" != "false" ]; then
     CMAKE_INSTALL_PREFIX="/tmp/s2_absl_$$"
   else
     CMAKE_INSTALL_PREFIX="`pwd`/tools/dist"


### PR DESCRIPTION
We're now in a unique enough phase with the vendored version of s2geometry that we need to pin an Abseil version. This is needed because the versions of Abseil included in modern distributions are new enough that the older version of s2geometry uses deprecated functionality (so we get CRAN warnings from the resulting C++ compiler warnings). We can't get out of this by upgrading s2geometry because newer s2geometry requires pinning a newer version of Abseil that is not yet available in modern Linux.

This PR forces building a vendored copy of Abseil, installing it into a temporary directory, then statically linking it. This can be opted out by setting `S2_FORCE_BUNDLED_ABSEIL=false`.

There are a few options for longer-term fixes that I will explore this month to attempt a more sustainable endpoint to this issue.

Closes #293.

