### PR TITLE
Only bundle by default on Linux

### DIFF
--- a/configure
+++ b/configure
@@ -69,7 +69,7 @@ export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:`pwd`/tools/pkgconfig"
 
 echo "** Using PKG_CONFIG_PATH=${PKG_CONFIG_PATH}"
 
-if [ -z "$S2_FORCE_BUNDLED_ABSEIL" ]; then
+if [ -z "$S2_FORCE_BUNDLED_ABSEIL" ] && [ "`uname -s`" = "Linux" ]; then
   S2_FORCE_BUNDLED_ABSEIL=true
 fi
 

--- a/tools/build_absl.sh
+++ b/tools/build_absl.sh
@@ -8,7 +8,7 @@ fi
 
 # Do our best to pass on the user MAKEFLAGS. This can result in much faster
 # compilation of the vendored library.
-MAKEFLAGS=`${R_HOME}/bin/Rscript -e 'readRenviron("~/.R/Makevars"); cat(Sys.getenv("MAKEFLAGS"))'`
+MAKEFLAGS=`${R_HOME}/bin/Rscript -e 'readRenviron(Sys.getenv("R_MAKEVARS_USER", "~/.R/Makevars")); cat(Sys.getenv("MAKEFLAGS"))'`
 
 if test -z "$MAKE"; then MAKE="`which make`"; fi
 if ${MAKE} --version ; then
@@ -19,7 +19,7 @@ else
 fi
 
 if test -z "$CMAKE"; then CMAKE="`which cmake`"; fi
-if test -z "$CMAKE" && [ -f "/Applications/CMake.app/Contents/bin/cmake" ]; then 
+if test -z "$CMAKE" && [ -f "/Applications/CMake.app/Contents/bin/cmake" ]; then
   CMAKE=/Applications/CMake.app/Contents/bin/cmake
 fi
 

--- a/tools/vendor/abseil-cpp/absl/container/internal/raw_hash_set.h
+++ b/tools/vendor/abseil-cpp/absl/container/internal/raw_hash_set.h
@@ -574,7 +574,7 @@ inline bool IsEmptyOrDeleted(ctrl_t c) { return c < ctrl_t::kSentinel; }
 inline __m128i _mm_cmpgt_epi8_fixed(__m128i a, __m128i b) {
 #if defined(__GNUC__) && !defined(__clang__)
   if (std::is_unsigned<char>::value) {
-    const __m128i mask = _mm_set1_epi8(static_cast<char>(-128));
+    const __m128i mask = _mm_set1_epi8(static_cast<char>(0x80));
     const __m128i diff = _mm_subs_epi8(b, a);
     return _mm_cmpeq_epi8(_mm_and_si128(diff, mask), mask);
   }

--- a/tools/vendor/abseil-cpp/absl/container/internal/raw_hash_set.h
+++ b/tools/vendor/abseil-cpp/absl/container/internal/raw_hash_set.h
@@ -574,7 +574,7 @@ inline bool IsEmptyOrDeleted(ctrl_t c) { return c < ctrl_t::kSentinel; }
 inline __m128i _mm_cmpgt_epi8_fixed(__m128i a, __m128i b) {
 #if defined(__GNUC__) && !defined(__clang__)
   if (std::is_unsigned<char>::value) {
-    const __m128i mask = _mm_set1_epi8(static_cast<char>(0x80));
+    const __m128i mask = _mm_set1_epi8(static_cast<char>(-128));
     const __m128i diff = _mm_subs_epi8(b, a);
     return _mm_cmpeq_epi8(_mm_and_si128(diff, mask), mask);
   }


### PR DESCRIPTION
This limits the default bundling to happen only on Linux, where CRAN may have a newer version of Abseil that causes deprecation warnings.